### PR TITLE
Add cache to get gateway

### DIFF
--- a/billing/gateway.py
+++ b/billing/gateway.py
@@ -1,6 +1,8 @@
 from django.utils.importlib import import_module
 from django.conf import settings
 
+gateway_cache = {}
+
 class GatewayModuleNotFound(Exception):
     pass
 
@@ -88,18 +90,35 @@ class Gateway(object):
         raise NotImplementedError
 
 def get_gateway(gateway, *args, **kwargs):
-    """Return a gateway instance specified by `gateway` name"""
-    gateway_filename = "%s_gateway" %gateway
-    gateway_module = None
-    for app in settings.INSTALLED_APPS:
+    """
+    Return a gateway instance specified by `gateway` name.
+    This caches gateway classes in a module-level dictionnary to avoid hitting
+    the filesystem every time we require a gateway.
+    
+    Should the list of available gateways change at runtime, one should then 
+    invalidate the cache, the simplest of ways would be to:
+    
+    >>> gateway_cache = {}
+    """
+    # Is the class in the cache?
+    clazz = gateway_cache.get(gateway, None)
+    
+    if not clazz:
+        # Let's actually load it (it's not in the cache)
+        gateway_filename = "%s_gateway" %gateway
+        gateway_module = None
+        for app in settings.INSTALLED_APPS:
+            try:
+                gateway_module = import_module(".gateways.%s" %gateway_filename, package=app)
+            except ImportError:
+                pass
+        if not gateway_module:
+            raise GatewayModuleNotFound("Missing gateway")
+        gateway_class_name = "".join(gateway_filename.title().split("_"))
         try:
-            gateway_module = import_module(".gateways.%s" %gateway_filename, package=app)
-        except ImportError:
-            pass
-    if not gateway_module:
-        raise GatewayModuleNotFound("Missing gateway")
-    gateway_class_name = "".join(gateway_filename.title().split("_"))
-    try:
-        return getattr(gateway_module, gateway_class_name)(*args, **kwargs)
-    except AttributeError:
-        raise GatewayNotConfigured("Missing %s class in the gateway module." %gateway_class_name)
+            clazz = getattr(gateway_module, gateway_class_name)
+        except AttributeError:
+            raise GatewayNotConfigured("Missing %s class in the gateway module." %gateway_class_name)
+    # We either hit the cache or load our class object, let's return an instance
+    # of it.
+    return clazz(*args, **kwargs)


### PR DESCRIPTION
I added a cache to the get_gateway() method to avoid looping over app installed apps in the filesystem every time we ask for a new gateway instance.
