### PR TITLE
Added a basic bitcoin gateway with an example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,11 @@ Off-Site Processing
 * eWAY
 * Authorize.net Direct Post Method
 
+Other
+-----
+
+* Bitcoin
+
 Documentation
 --------------
 

--- a/billing/gateways/bitcoin_gateway.py
+++ b/billing/gateways/bitcoin_gateway.py
@@ -1,0 +1,65 @@
+import bitcoinrpc
+
+from decimal import Decimal
+
+from billing import Gateway, GatewayNotConfigured
+from billing.signals import transaction_was_unsuccessful, \
+    transaction_was_successful
+from billing.utils.credit_card import CreditCard
+from django.conf import settings
+from django.utils import simplejson as json
+
+
+class BitcoinGateway(Gateway):
+    display_name = "Bitcoin"
+    homepage_url = "http://bitcoin.org/"
+
+    def __init__(self):
+        test_mode = getattr(settings, "MERCHANT_TEST_MODE", True)
+        merchant_settings = getattr(settings, "MERCHANT_SETTINGS")
+        if not merchant_settings or not merchant_settings.get("bitcoin"):
+            raise GatewayNotConfigured("The '%s' gateway is not correctly "
+                                       "configured." % self.display_name)
+        bitcoin_settings = merchant_settings["bitcoin"]
+
+        self.rpcuser = bitcoin_settings["RPCUSER"]
+        self.rpcpassword = bitcoin_settings["RPCPASSWORD"]
+        self.host = bitcoin_settings.get("HOST", "127.0.0.1")
+        self.port = bitcoin_settings.get("PORT", "8332")
+        self.account = bitcoin_settings["ACCOUNT"]
+        self.minconf = bitcoin_settings.get("MINCONF", 1)
+
+        self.connection = bitcoinrpc.connect_to_remote(
+                self.rpcuser,
+                self.rpcpassword,
+                self.host,
+                self.port
+        )
+
+    def get_new_address(self):
+        return self.connection.getnewaddress(self.account)
+
+    def get_transactions(self):
+        return self.connection.listtransactions(self.account)
+
+    def get_transactions_by_address(self, address):
+        all_txns = self.get_transactions()
+        return filter(lambda txn: txn.address == address, all_txns)
+
+    def get_txns_sum(self, txns):
+        return sum(txn.amount for txn in txns)
+
+    def purchase(self, money, address, options = None):
+        options = options or {}
+        txns = self.get_transactions_by_address(address)
+        received = self.get_txns_sum(txns)
+        response = [txn.__dict__ for txn in txns]
+        if received == money:
+            transaction_was_successful.send(sender=self,
+                                            type="purchase",
+                                            response=response)
+            return {'status': 'SUCCESS', 'response': response}
+        transaction_was_unsuccessful.send(sender=self,
+                                          type="purchase",
+                                          response=response)
+        return {'status': 'FAILURE', 'response': response}

--- a/billing/tests/__init__.py
+++ b/billing/tests/__init__.py
@@ -40,6 +40,7 @@ except ImportError:
     
 from paylane_tests import *
 from chargebee_tests import *
+from bitcoin_tests import *
 
 if __name__ == "__main__":
     unittest.main()

--- a/billing/tests/bitcoin_tests.py
+++ b/billing/tests/bitcoin_tests.py
@@ -1,0 +1,40 @@
+from django.test import TestCase
+from billing import get_gateway
+from billing.signals import *
+from billing.models import EwayResponse
+from billing.gateway import CardNotSupported
+from billing.utils.credit_card import Visa
+
+
+class BitcoinGatewayTestCase(TestCase):
+    def setUp(self):
+        self.merchant = get_gateway("bitcoin")
+        self.address = self.merchant.get_new_address()
+
+    def testPurchase(self):
+        self.merchant.connection.sendtoaddress(self.address, 1)
+        resp = self.merchant.purchase(1, self.address)
+        self.assertEquals(resp['status'], 'SUCCESS')
+
+    def testPaymentSuccessfulSignal(self):
+        received_signals = []
+
+        def receive(sender, **kwargs):
+            received_signals.append(kwargs.get("signal"))
+
+        transaction_was_successful.connect(receive)
+
+        self.merchant.connection.sendtoaddress(self.address, 1)
+        resp = self.merchant.purchase(1, self.address)
+        self.assertEquals(received_signals, [transaction_was_successful])
+
+    def testPaymentUnSuccessfulSignal(self):
+        received_signals = []
+
+        def receive(sender, **kwargs):
+            received_signals.append(kwargs.get("signal"))
+
+        transaction_was_unsuccessful.connect(receive)
+
+        resp = self.merchant.purchase(0.01, self.address)
+        self.assertEquals(received_signals, [transaction_was_unsuccessful])

--- a/docs/gateways/bitcoin_gateway.rst
+++ b/docs/gateways/bitcoin_gateway.rst
@@ -1,0 +1,40 @@
+-------------
+Bitcoin Gateway
+-------------
+
+The Bitcoin gateway implements the `Bitcoin digital currency`_.
+
+It is implemented using the JSON-RPC API as described in the `Merchant Howto`_.
+
+.. note::
+
+     The Bitcoin gateway depends on the `bitcoin-python` library which
+     can be installed from pypi
+
+Usage
+------
+
+* Add the following attributes to your `settings.py`::
+
+    "bitcoin": {
+        "RPCUSER": "", # you'll find these settings in your $HOME/.bitcoin/bitcoin.conf
+        "RPCPASSWORD": "",
+        "HOST": "",
+        "PORT": "",
+        "ACCOUNT": "",
+        "MINCONF": 1,
+    },
+
+* Use the gateway instance::
+
+    >>> g1 = get_gateway("bitcoin")
+    >>> addr = g1.get_new_address()
+    >>> # pass along this address to your customer
+    >>> # the purchase will only be successful when
+    >>> # the amount is transferred to the above address
+    >>> response1 = g1.purchase(100, addr, options = {...})
+    >>> response1
+    {"status": "SUCCESS", "response": <instance>}
+
+.. _`Bitcoin digital currency`: http://bitcoin.org/
+.. _`Merchant Howto`: https://en.bitcoin.it/wiki/Merchant_Howto#Using_a_third-party_plugin

--- a/example/app/templates/app/base.html
+++ b/example/app/templates/app/base.html
@@ -29,7 +29,9 @@
     <a href='{% url app_offsite_stripe %}'>Stripe</a>
     <a href='{% url app_offsite_samurai %}'>Samurai</a>
     <a href='{% url app_offsite_eway %}'>eWAY</a>
-
+  <br/><br/>
+  Other:
+    <a href='{% url app_bitcoin %}'>Bitcoin</a>
   <h1>{{ title }} </h1>
   {% block content %}
 

--- a/example/app/templates/app/bitcoin.html
+++ b/example/app/templates/app/bitcoin.html
@@ -1,0 +1,15 @@
+{% extends 'app/base.html' %}
+
+{% block content %}
+Please pay 1 BTC to the following address from your bitcoin wallet:
+<br />
+<strong>{{ address }}</strong>
+
+<br />
+Click continue when done.
+
+<form action="/bitcoin/done/" method="POST">
+    {% csrf_token %}
+    <input type="submit" name="continue" value="Continue" />
+</form>
+{% endblock %}

--- a/example/app/templates/app/bitcoin_done.html
+++ b/example/app/templates/app/bitcoin_done.html
@@ -1,0 +1,21 @@
+{% extends 'app/base.html' %}
+
+{% block content %}
+Paying 1 BTC  to address: {{ address }}
+<br />
+
+<strong>Result</strong>: {{ result.status }}
+
+<ol>
+    {% for txn in result.response %}
+    <li>Received: {{ txn.amount }} BTC - transaction id: {{ txn.txid }}</li>
+    {% empty %}
+    <li>No transactions to this address so far.</li>
+    <form action="." method="POST">
+        {% csrf_token %}
+        <input type="submit" name="retry" value="Retry" />
+    </form>
+    {% endfor %}
+</ol>
+
+{% endblock %}

--- a/example/app/urls.py
+++ b/example/app/urls.py
@@ -23,6 +23,8 @@ urlpatterns = patterns('app.views',
     url(r'^paylane/$', 'paylane', name='app_paylane'),
     url(r'^beanstream/$', 'beanstream', name='app_beanstream'),
     url(r'^chargebee/$', 'chargebee', name='app_chargebee'),
+    url(r'^bitcoin/$', 'bitcoin', name='app_bitcoin'),
+    url(r'^bitcoin/done/$', 'bitcoin_done', name='app_bitcoin_done'),
 )
 
 # offsite payments

--- a/example/app/views.py
+++ b/example/app/views.py
@@ -409,3 +409,30 @@ def offsite_eway_done(request):
     result = eway_obj.check_transaction(access_code)
 
     return render(request, "app/eway_done.html", {"result": result}) 
+
+
+def bitcoin(request):
+    bitcoin_obj = get_gateway("bitcoin")
+    address = request.session.get("bitcoin_address", None)
+    if not address:
+        address = bitcoin_obj.get_new_address()
+        request.session["bitcoin_address"] = address
+    return render(request, "app/bitcoin.html", {
+        "title": "Bitcoin",
+        "address": address
+    })
+
+def bitcoin_done(request):
+    amount = 1
+    bitcoin_obj = get_gateway("bitcoin")
+    address = request.session.get("bitcoin_address", None)
+    if not address:
+        return HttpResponseRedirect(reverse("app_bitcoin"))
+    result = bitcoin_obj.purchase(amount, address)
+    if result['status'] == 'SUCCESS':
+        del request.session["bitcoin_address"]
+    return render(request, "app/bitcoin_done.html", {
+        "title": "Bitcoin",
+        "address": address,
+        "result": result
+    })

--- a/example/localsettings.example.py
+++ b/example/localsettings.example.py
@@ -92,7 +92,21 @@ MERCHANT_SETTINGS = {
         # Below two are optional
         "HASH_ALGORITHM"   : "",
         "HASHCODE"  : ""
-    }
+    },
+
+    "chargebee": {
+        "API_KEY": "",
+        "SITE": ""
+    },
+
+    "bitcoin": {
+        "RPCUSER": "",
+        "RPCPASSWORD": "",
+        "HOST": "",
+        "PORT": "",
+        "ACCOUNT": "",
+        "MINCONF": 1,
+    },
 }
 
 # Special case for PayPal because we rely on django-paypal


### PR DESCRIPTION
I've added a bitcoin backend based on the JSON-RPC API.

Depends on the package `bitcoin-python`

http://laanwj.github.com/bitcoin-python/

Tested with testnet-in-a-box

http://sourceforge.net/projects/bitcoin/files/Bitcoin/testnet-in-a-box/
