### PR TITLE
Fixed a typo in the google checkout docs

### DIFF
--- a/docs/offsite/google_checkout.rst
+++ b/docs/offsite/google_checkout.rst
@@ -33,11 +33,12 @@ Example
 
 In urls.py::
 
+  from billing import get_integration
   gc = get_integration("google_checkout")
   urlpatterns += patterns('',
     (r'^gc/', include(gc.urls)),
-    # You'll have to register /gc/gc-notify-handler/ in the
-    # WorldPay admin dashboard for the notification URL
+    # You'll have to add /gc/gc-notify-handler/ to the
+    # Google Checkout settings->Integration page for the callback URL
   )
 
 In views.py::


### PR DESCRIPTION
Fixed a typo in the google checkout docs that referenced worldpay instead of google checkout. 
Also added a missing import to the urls.py example.
