### PR TITLE
Use the MERCHANT_TEST_MODE when generating FPS URL.

### DIFF
--- a/billing/integrations/amazon_fps_integration.py
+++ b/billing/integrations/amazon_fps_integration.py
@@ -46,6 +46,7 @@ class AmazonFpsIntegration(Integration):
         self.aws_access_key = options.get("aws_access_key", None) or amazon_fps_settings['AWS_ACCESS_KEY']
         self.aws_secret_access_key = options.get("aws_secret_access_key", None) or amazon_fps_settings['AWS_SECRET_ACCESS_KEY']
         super(AmazonFpsIntegration, self).__init__(options=options)
+        options.setdefault('host', self.service_url)
         self.fps_connection = FPSConnection(self.aws_access_key, self.aws_secret_access_key, **options)
 
     @property


### PR DESCRIPTION
This adds a default option "host" for the `FPSConnection` so it  properly sends to sandbox/production when using the `MERCHANT_TEST_MODE` setting.

When using merchant 0.0.08a and boto 2.8.0 the service URL is always returned as the sandbox within boto, this additional option corrects that problem.
