### PR TITLE
Update worldpay host URLs.

### DIFF
--- a/billing/integrations/world_pay_integration.py
+++ b/billing/integrations/world_pay_integration.py
@@ -8,8 +8,8 @@ from billing.models.world_pay_models import WorldPayResponse
 from django.utils.decorators import method_decorator
 from billing.forms.world_pay_forms import WPHostedPaymentForm
 
-RBS_HOSTED_URL_TEST = "https://select-test.wp3.rbsworldpay.com/wcc/purchase"
-RBS_HOSTED_URL_LIVE = "https://secure.wp3.rbsworldpay.com/wcc/purchase"
+RBS_HOSTED_URL_TEST = "https://select-test.worldpay.com/wcc/purchase"
+RBS_HOSTED_URL_LIVE = "https://secure.worldpay.com/wcc/purchase"
 
 # http://www.rbsworldpay.com/support/bg/index.php?page=development&sub=integration&c=WW
 


### PR DESCRIPTION
WorldPay recently communicated that their host URLs are changing.

"If you were previously using RBS WorldPay links such as https://secure.wp3.rbsworldpay.com/wcc/purchase  you will need to ensure that these are replaced with https://secure.worldpay.com/wcc/purchase to ensure that your site continues to be able to send payments through WorldPay's systems."

The documentation currently lists the new URLs

http://www.worldpay.com/support/kb/bg/htmlredirect/rhtml.html

This change updates the URLs as required.
