### PR TITLE
Added new allowed fields for posting multiple items to PayPal

### DIFF
--- a/billing/forms/paypal_forms.py
+++ b/billing/forms/paypal_forms.py
@@ -1,8 +1,18 @@
 from django import forms
-
+import re
 
 from paypal.standard.forms import (PayPalPaymentsForm,
                                    PayPalEncryptedPaymentsForm)
+
+
+INTEGER_FIELDS = ('amount_', 'item_number_', 'quantity_', 'tax_', 'shipping_',
+                  'shipping2_', 'discount_amount_', 'discount_amount2_',
+                  'discount_rate_', 'discount_rate2_', 'discount_num_',
+                  'tax_rate_')
+INTEGER_FIELD_RE = re.compile(r'|'.join(re.escape(f) for f in INTEGER_FIELDS))
+
+CHAR_FIELDS = ('item_name_', 'on0_', 'on1_', 'os0_', 'os1_')
+CHAR_FIELD_RE = re.compile(r'|'.join(re.escape(f) for f in CHAR_FIELDS))
 
 
 class MultipleItemsMixin(object):
@@ -16,11 +26,11 @@ class MultipleItemsMixin(object):
         has_multiple_items = False
         if 'initial' in kwargs:
             for k, v in kwargs['initial'].items():
-                if k.startswith('amount_'):
+                if INTEGER_FIELD_RE.match(k):
                     self.fields[k] = forms.IntegerField(
                         widget=forms.widgets.HiddenInput())
                     has_multiple_items = True
-                elif  k.startswith('item_name_'):
+                elif CHAR_FIELD_RE.match(k):
                     has_multiple_items = True
                     self.fields[k] = forms.CharField(
                         widget=forms.widgets.HiddenInput())


### PR DESCRIPTION
Fixes #79: This should contain most allowable/necessary fields which PayPal allows you to post when sending multiple items in one shopping cart.

I accidentally included a change which I sent in a separate pull request, so I have reverse merged that. Hopefully that doesn't cause problems.
