### PR TITLE
Forced not configured gateways’ unit tests to skip

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -14,6 +14,7 @@ Thanks go out to all the contributors listed in alphabetical order:
 * Daniel Sokolowski <https://github.com/danols>
 * Donald Stufft <https://github.com/dstufft>
 * Dmitry Molotkov <https://github.com/aldarund>
+* FoxyProxy, Inc. <http://getfoxyproxy.org/>
 * Greg McGuire <https://github.com/gmcguire>
 * igorn <https://github.com/igonef>
 * Issac Kelly <http://www.issackelly.com/>
@@ -33,5 +34,6 @@ Thanks go out to all the contributors listed in alphabetical order:
 * Si Feng <https://github.com/devfeng>
 * Steve Phillips <https://github.com/elimisteve>
 * Thejaswi Puthraya <thejaswi.puthraya@gmail.com>
+* Tom Aratyn <tom@aratyn.name>
 * Venkata Ramana <arjunchitturi@gmail.com>
 * Jordi Llonch <https://github.com/llonchj>

--- a/billing/tests/amazon_fps_tests.py
+++ b/billing/tests/amazon_fps_tests.py
@@ -1,13 +1,15 @@
 from xml.dom import minidom
 from urllib2 import urlparse
 
+from django.conf import settings
 from django.test import TestCase
 from django.template import Template, Context
-from django.conf import settings
+from django.utils.unittest.case import skipIf
 
 from billing import get_integration
 
 
+@skipIf(not settings.MERCHANT_SETTINGS.get("", None), "gateway not configured")
 class AmazonFPSTestCase(TestCase):
     urls = "billing.tests.test_urls"
 

--- a/billing/tests/authorize_net_tests.py
+++ b/billing/tests/authorize_net_tests.py
@@ -1,7 +1,9 @@
 import mock
 import urllib2
 
+from django.conf import settings
 from django.test import TestCase
+from django.utils.unittest.case import skipIf
 
 from billing import get_gateway, CreditCard
 from billing.signals import *
@@ -11,6 +13,7 @@ from billing.gateways.authorize_net_gateway import MockAuthorizeAIMResponse
 from billing.utils.credit_card import Visa
 
 
+@skipIf(not settings.MERCHANT_SETTINGS.get("authroize_net", None), "gateway not configured")
 class AuthorizeNetAIMGatewayTestCase(TestCase):
     def setUp(self):
         self.merchant = get_gateway("authorize_net")

--- a/billing/tests/base_tests.py
+++ b/billing/tests/base_tests.py
@@ -1,11 +1,15 @@
+from django.conf import settings
 from django.test import TestCase
+from django.template import Template, Context, TemplateSyntaxError
+from django.utils.unittest.case import skipIf
+
 from billing.utils.credit_card import CreditCard
 from billing import get_gateway, GatewayNotConfigured, get_integration, IntegrationNotConfigured
-from django.conf import settings
-from django.template import Template, Context, TemplateSyntaxError
 
 
 class MerchantTestCase(TestCase):
+
+    @skipIf(not settings.MERCHANT_SETTINGS.get("authorize_net", None), "gateway not configured")
     def testCorrectClassLoading(self):
         gateway = get_gateway("authorize_net")
         self.assertEquals(gateway.display_name, "Authorize.Net")

--- a/billing/tests/beanstream_tests.py
+++ b/billing/tests/beanstream_tests.py
@@ -1,13 +1,18 @@
 from datetime import date
+
+from django.conf import settings
 from django.test import TestCase
+from django.utils.unittest.case import skipIf
+
 from billing import get_gateway, CreditCard
 from billing.signals import *
-from billing.models import AuthorizeAIMResponse
 from billing.gateway import CardNotSupported
 from billing.utils.credit_card import Visa
 
 from beanstream.billing import Address
 
+
+@skipIf(not settings.MERCHANT_SETTINGS.get("beanstream", None), "gateway not configured")
 class BeanstreamGatewayTestCase(TestCase):
     approved_cards = {'visa': {'number':      '4030000010001234', 'cvd': '123'},
                        '100_visa': {'number': '4504481742333', 'cvd': '123'},

--- a/billing/tests/bitcoin_tests.py
+++ b/billing/tests/bitcoin_tests.py
@@ -1,10 +1,15 @@
+from django.conf import settings
 from django.test import TestCase
+from django.utils.unittest.case import skipIf
+
 from billing import get_gateway
 from billing.signals import transaction_was_successful, transaction_was_unsuccessful
+
 
 TEST_AMOUNT = 0.01
 
 
+@skipIf(not settings.MERCHANT_SETTINGS.get("bitcoin", None), "gateway not configured")
 class BitcoinGatewayTestCase(TestCase):
     def setUp(self):
         self.merchant = get_gateway("bitcoin")

--- a/billing/tests/braintree_payments_tests.py
+++ b/billing/tests/braintree_payments_tests.py
@@ -1,6 +1,8 @@
 import braintree
 
+from django.conf import settings
 from django.test import TestCase
+from django.utils.unittest.case import skipIf
 
 from billing import get_gateway, CreditCard
 from billing.signals import *
@@ -8,6 +10,7 @@ from billing.gateway import CardNotSupported, InvalidData
 from billing.utils.credit_card import Visa
 
 
+@skipIf(not settings.MERCHANT_SETTINGS.get("braintree_payments", None), "gateway not configured")
 class BraintreePaymentsGatewayTestCase(TestCase):
     def setUp(self):
         self.merchant = get_gateway("braintree_payments")

--- a/billing/tests/braintree_payments_tr_tests.py
+++ b/billing/tests/braintree_payments_tr_tests.py
@@ -1,13 +1,14 @@
 """
 Braintree Payments Transparent Redirect Tests.
 """
-from django.test import TestCase
-from django.utils.html import strip_spaces_between_tags
-from billing import get_integration
-from django.template import Template, Context
 from django.conf import settings
+from django.test import TestCase
+from django.utils.unittest.case import skipIf
+
+from billing import get_integration
 
 
+@skipIf(not settings.MERCHANT_SETTINGS.get("braintree_payments", None), "gateway not configured")
 class BraintreePaymentsIntegrationTestCase(TestCase):
     urls = "billing.tests.test_urls"
 

--- a/billing/tests/chargebee_tests.py
+++ b/billing/tests/chargebee_tests.py
@@ -1,9 +1,13 @@
+from django.conf import settings
 from django.test import TestCase
+from django.utils.unittest.case import skipIf
+
 from billing import get_gateway, CreditCard
 from billing.signals import transaction_was_successful, \
     transaction_was_unsuccessful
 
 
+@skipIf(not settings.MERCHANT_SETTINGS.get("chargebee", None), "gateway not configured")
 class ChargebeeGatewayTestCase(TestCase):
     def setUp(self):
         self.merchant = get_gateway("chargebee")

--- a/billing/tests/eway_tests.py
+++ b/billing/tests/eway_tests.py
@@ -1,4 +1,7 @@
+from django.conf import settings
 from django.test import TestCase
+from django.utils.unittest.case import skipIf
+
 from billing import get_gateway, CreditCard
 from billing.signals import *
 from billing.models import EwayResponse
@@ -40,7 +43,7 @@ fake_options = {
     }
 }
 
-
+@skipIf(not settings.MERCHANT_SETTINGS.get("eway", None), "gateway not configured")
 class EWayGatewayTestCase(TestCase):
     def setUp(self):
         self.merchant = get_gateway("eway")

--- a/billing/tests/google_checkout_tests.py
+++ b/billing/tests/google_checkout_tests.py
@@ -5,8 +5,10 @@ from django.test import TestCase
 from django.template import Template, Context
 
 from billing import get_integration
+from django.utils.unittest.case import skipIf
 
 
+@skipIf(not settings.MERCHANT_SETTINGS.get("google_checkout", None), "gateway not configured")
 class GoogleCheckoutTestCase(TestCase):
     def setUp(self):
         self.gc = get_integration("google_checkout")
@@ -62,7 +64,7 @@ class GoogleCheckoutTestCase(TestCase):
         good_xml = """<?xml version="1.0" encoding="utf-8"?><checkout-shopping-cart xmlns="http://checkout.google.com/schema/2"><shopping-cart><items><item><item-name>name of the item</item-name><item-description>Item description</item-description><unit-price currency="USD">0.0</unit-price><quantity>1</quantity><merchant-item-id>999AXZ</merchant-item-id><subscription period="YEARLY" type="merchant"><payments><subscription-payment><maximum-charge currency="USD">9.99</maximum-charge></subscription-payment></payments></subscription><digital-content><display-disposition>OPTIMISTIC</display-disposition><description>Congratulations! Your subscription is being set up. Feel free to log onto &amp;amp;lt;a href=\'http://example.com/offsite/my_content/\'&amp;amp;gt;example.com/offsite/my_content/&amp;amp;lt;/a&amp;amp;gt; and try it out!</description></digital-content></item></items><merchant-private-data>test@example.com</merchant-private-data></shopping-cart><checkout-flow-support><merchant-checkout-flow-support><continue-shopping-url>http://127.0.0.1:8000/offsite/google-checkout/</continue-shopping-url></merchant-checkout-flow-support></checkout-flow-support></checkout-shopping-cart>"""
         self.assertEquals(xml, good_xml)
 
-
+@skipIf(not settings.MERCHANT_SETTINGS.get("google_checkout", None), "gateway not configured")
 class GoogleCheckoutShippingTestCase(TestCase):
     def setUp(self):
         self.gc = get_integration("google_checkout")
@@ -213,6 +215,7 @@ class GoogleCheckoutShippingTestCase(TestCase):
         self.assertEquals(xml, good_xml)
 
 
+@skipIf(not settings.MERCHANT_SETTINGS.get("google_checkout", None), "gateway not configured")
 class GoogleCheckoutTaxTestCase(TestCase):
     """ Test the tax code """
 

--- a/billing/tests/ogone_payments_tests.py
+++ b/billing/tests/ogone_payments_tests.py
@@ -1,7 +1,11 @@
+from django.conf import settings
 from django.test import TestCase
+from django.utils.unittest.case import skipIf
+
 from billing import get_integration
 
 
+@skipIf(not settings.MERCHANT_SETTINGS.get("ogone_payments", None), "gateway not configured")
 class OgonePaymentsTestCase(TestCase):
     def setUp(self):
         self.op = get_integration("ogone_payments")

--- a/billing/tests/pay_pal_tests.py
+++ b/billing/tests/pay_pal_tests.py
@@ -2,10 +2,12 @@ import datetime
 from urllib2 import urlparse
 from xml.dom import minidom
 
+from django.conf import settings
 from django.test.client import RequestFactory
 from django.template import Template, Context
 from django.core.urlresolvers import reverse
 from django.test import TestCase
+from django.utils.unittest.case import skipIf
 
 from paypal.pro.models import PayPalNVP
 
@@ -29,7 +31,7 @@ fake_options = {
     },
 }
 
-
+@skipIf(not settings.MERCHANT_SETTINGS.get("pay_pal", None), "gateway not configured")
 class PayPalGatewayTestCase(TestCase):
     def setUp(self):
         self.merchant = get_gateway("pay_pal")
@@ -91,6 +93,7 @@ class PayPalGatewayTestCase(TestCase):
         self.assertNotEquals(resp["status"], "SUCCESS")
 
 
+@skipIf(not settings.MERCHANT_SETTINGS.get("pay_pal", None), "gateway not configured")
 class PayPalWebsiteStandardsTestCase(TestCase):
     urls = "billing.tests.test_urls"
 

--- a/billing/tests/paylane_tests.py
+++ b/billing/tests/paylane_tests.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # vim:tabstop=4:expandtab:sw=4:softtabstop=4
-from unittest import skipIf
 
-from django.test import TestCase
 from django.conf import settings
+from django.test import TestCase
+from django.utils.unittest.case import skipIf
 
 from billing.gateway import CardNotSupported
 from billing.utils.credit_card import Visa, CreditCard
@@ -13,6 +13,8 @@ from billing.utils.paylane import *
 from billing.models import PaylaneTransaction, PaylaneAuthorization
 
 #This is needed because Paylane doesn't like too many requests in a very short time
+
+
 THROTTLE_CONTROL_SECONDS = 60
 
 # VISA test card numbers

--- a/billing/tests/pin_tests.py
+++ b/billing/tests/pin_tests.py
@@ -1,6 +1,7 @@
+from django.conf import settings
 from django.test import TestCase
+from django.utils.unittest.case import skipIf
 from billing import get_gateway, CreditCard
-from billing.signals import transaction_was_successful, transaction_was_unsuccessful
 
 VISA_SUCCESS = '4200000000000000'
 VISA_FAILURE = '4100000000000001'
@@ -20,6 +21,8 @@ OPTIONS = {
     },
 }
 
+
+@skipIf(not settings.MERCHANT_SETTINGS.get("pin", None), "gateway not configured")
 class PinGatewayTestCase(TestCase):
     def setUp(self):
         self.merchant = get_gateway("pin")

--- a/billing/tests/stripe_tests.py
+++ b/billing/tests/stripe_tests.py
@@ -2,10 +2,11 @@ from django.test import TestCase
 from billing import get_gateway, CreditCard
 from billing.gateway import CardNotSupported
 from billing.utils.credit_card import Visa
+from django.utils.unittest.case import skipIf
 import stripe
 from django.conf import settings
 
-
+@skipIf(not settings.MERCHANT_SETTINGS.get("stripe", None), "gateway not configured")
 class StripeGatewayTestCase(TestCase):
     def setUp(self):
         self.merchant = get_gateway("stripe")


### PR DESCRIPTION
When a new user downloads merchant it can be discomforting when so many tests fail just because they don't have test accounts for so many payment gateways. This PR makes sure that only the configured gateways' tests run. 
