### PR TITLE
Update rbs_worldpay.rst

### DIFF
--- a/docs/offsite/rbs_worldpay.rst
+++ b/docs/offsite/rbs_worldpay.rst
@@ -54,8 +54,8 @@ In views.py::
 
 In some_template.html::
 
-  {% load render_integration from billing_tags %}
-  {% render_integration obj %}
+  {% load world_pay from world_pay_tags %}
+  {% world_pay obj %}
 
 Template renders to something like below::
 


### PR DESCRIPTION
Looks like someone has created a special case world_pay template tag and not updated the docs?
I'm using this in my project now and it's working however I'm not sure if the settings are working properly. I had to:

``` python
world_pay = get_integration("world_pay") 
world_pay.add_fields(settings.MERCHANT_SETTINGS['world_pay'])
```

Will hopefully get around to having a look at soon.
