### PR TITLE
Update world_pay.html

### DIFF
--- a/billing/templates/billing/world_pay.html
+++ b/billing/templates/billing/world_pay.html
@@ -1,4 +1,4 @@
 <form method='post' action='{{ integration.service_url }}'>
-    {{ form }}
+    {{ integration.generate_form }}
     <input type='submit' value='Pay through WorldPay'/>
 </form>


### PR DESCRIPTION
As per #95 if you're not going to use the world_pay templatetag then the default template needs to be updated to accept the form from the integration object rather than expect it directly in the context.

In the world_pay tag we were have:

```
    form_str = render_to_string("billing/world_pay.html",
                                {"form": int_obj.generate_form(),
                                 "integration": int_obj}, context)
```

In the render_integration tag we pass:

```
    form_str = render_to_string(
            int_obj.template, {
                "integration": int_obj
            },context)
```

Therefore the default worldpay template was not receiving the 'form' but was receiving the 'integration'
