### PR TITLE
add is_valid fake method to enable beanstream credit cards

### DIFF
--- a/billing/gateway.py
+++ b/billing/gateway.py
@@ -58,7 +58,10 @@ class Gateway(object):
         # might not pass Luhn's test.
         if self.test_mode:
             return True
-        return credit_card.is_valid()
+        valid_method = getattr(credit_card, 'is_valid', False)
+        if valid_method:
+            return valid_method()
+        return True
 
     def purchase(self, money, credit_card, options=None):
         """One go authorize and capture transaction"""

--- a/billing/gateways/beanstream_gateway.py
+++ b/billing/gateways/beanstream_gateway.py
@@ -95,11 +95,6 @@ class BeanstreamGateway(Gateway):
             credit_card.number,
             credit_card.month, credit_card.year,
             credit_card.verification_value)
-        if not hasattr(card, 'is_valid'):
-            # there is no is_valid on the beanstream credit card object
-            def is_valid():
-                return True
-            card.is_valid = is_valid
         if validate:
             self.validate_card(card)
         return card


### PR DESCRIPTION
The credit card beanstream uses does not have an is_valid method so the validation method fails. This puts in a fake is_valid method if one doesn't exist (so if they ever do add a method it will work seamlessly).
