### PR TITLE
Fixed support for AUD

### DIFF
--- a/billing/gateways/global_iris_gateway.py
+++ b/billing/gateways/global_iris_gateway.py
@@ -76,7 +76,7 @@ class GlobalIrisBase(object):
             all_data['timestamp'] = datetime.now()
         all_data['timestamp'] = self.make_timestamp(all_data['timestamp'])
         currency = all_data['currency']
-        if currency in ['GBP', 'USD', 'EUR']:
+        if currency in ['GBP', 'USD', 'EUR', 'AUD']:
             all_data['amount_normalized'] = int(all_data['amount'] * Decimal('100.00'))
         else:
             raise ValueError("Don't know how to normalise amounts in currency %s" % currency)


### PR DESCRIPTION
This adds support for AUD to the currencies support by the Global Iris gateway.

(We can't just add all currencies, because we don't yet have an adequate answer to the question of what factor to use for every currency, in the line `all_data['amount'] * Decimal('100.00')`. Global Iris haven't been very helpful about this!)