### PR TITLE
Fix stripe test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ example/tmp
 example/localsettings.py
 
 docs/_build/*
+.idea
 
 *_flymake.py*
 #*

--- a/billing/tests/test_stripe.py
+++ b/billing/tests/test_stripe.py
@@ -41,8 +41,10 @@ class StripeGatewayTestCase(TestCase):
     def testStoreWithoutBillingAddress(self):
         resp = self.merchant.store(self.credit_card)
         self.assertEquals(resp["status"], "SUCCESS")
-        self.assertEquals(resp["response"].active_card.exp_month, self.credit_card.month)
-        self.assertEquals(resp["response"].active_card.exp_year, self.credit_card.year)
+        self.assertEquals(resp["response"]["sources"]["data"][0].exp_month,
+                          self.credit_card.month)
+        self.assertEquals(resp["response"]["sources"]["data"][0].exp_year,
+                          self.credit_card.year)
         self.assertTrue(getattr(resp["response"], "id"))
         self.assertTrue(getattr(resp["response"], "created"))
 
@@ -66,7 +68,7 @@ class StripeGatewayTestCase(TestCase):
         options = {"plan_id": plan_id}
         resp = self.merchant.recurring(self.credit_card, options=options)
         self.assertEquals(resp["status"], "SUCCESS")
-        subscription = resp["response"].subscription
+        subscription = resp["response"].subscriptions["data"][0]
         self.assertEquals(subscription.status, "active")
 
     def testCredit(self):


### PR DESCRIPTION
The two test cases, testRecurring1, and testStoreWithoutBillingAddress, are not working. This is a minor fix to the two tests. 
In addition to the fix, since I use PyCharm IDE and I believe many others do as well, I suppose it wouldn't hurt to ignore the aux files folder in .gitignore. 